### PR TITLE
Concise callback creation. 

### DIFF
--- a/synoptic/tabs/__init__.py
+++ b/synoptic/tabs/__init__.py
@@ -93,7 +93,6 @@ class MainSynopticTab(QtWidgets.QDialog):
         # ptr = QtCompat.getCppPointer(self)
 
         self.cbManager = callbackManager.CallbackManager()
-        self.cbManager.selectionChangedCB("SynopticTab", self.selectChanged)
 
     def selectChanged(self, *args):
         # wrap to catch exception guaranteeing core does not stop at this

--- a/synoptic/tabs/biped/__init__.py
+++ b/synoptic/tabs/biped/__init__.py
@@ -29,6 +29,7 @@ class SynopticTab(MainSynopticTab, widget.Ui_biped_body):
     # INIT
     def __init__(self, parent=None):
         super(SynopticTab, self).__init__(self, parent)
+        self.cbManager.selectionChangedCB(self.name, self.selectChanged)
 
     # ============================================
     # BUTTONS

--- a/synoptic/tabs/quadruped/__init__.py
+++ b/synoptic/tabs/quadruped/__init__.py
@@ -17,3 +17,4 @@ class SynopticTab(MainSynopticTab, widget.Ui_biped_body):
     # INIT
     def __init__(self, parent=None):
         super(SynopticTab, self).__init__(self, parent)
+        self.cbManager.selectionChangedCB(self.name, self.selectChanged)


### PR DESCRIPTION
Moving the creation of the callback from baseclass to ensure we only created the number of callbacks needed.